### PR TITLE
Added Package.swift for usage of the Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:4.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "KVVlive",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "KVVlive",
+            targets: ["KVVlive"]),
+        ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "KVVlive",
+            dependencies: [],
+            path: "KVVlive"),
+        ]
+)


### PR DESCRIPTION
I added a Package.swift file to your project, which makes your project compatible with the swift package manager.
If you would also create a release with the tag "1.0.0" on GitHub, one could easily import your API as a dependency by adding
```swift
.package(url: "https://github.com/mdvjd/kvvliveapi.git", from: "1.0.0")
```
to his Package.swift `dependencies` array.